### PR TITLE
Remove system-repart workaround for fstab generation

### DIFF
--- a/systemd-repart-dracut
+++ b/systemd-repart-dracut
@@ -35,10 +35,6 @@ if ! [ -w /sysroot/etc ]; then
         fi
 fi
 
-# Delete the systemd-repart marker in /sysroot/etc/fstab, or systemd-repart
-# can remove entries it should not
-sed -i -e 's|# .*section.*of automatically generated fstab by systemd-repart||g' /sysroot/etc/fstab
-
 log_info "Reparting with systemd-repart:"
 /usr/bin/systemd-repart --dry-run=no --append-fstab=auto --generate-fstab=/etc/fstab
 log_info "Repartition completed"


### PR DESCRIPTION
The issue has been fixed [here](https://github.com/thkukuk/opensuse-mkosi-images/pull/3).